### PR TITLE
player tracking fixes/updates

### DIFF
--- a/config.php-dist
+++ b/config.php-dist
@@ -15,6 +15,7 @@
 	$enableclock = 0; // show game time clock in upper left corner
 	$enableTracking = 1; // show tracks of player/vehicle movement on the map
 	$maxTrackingPositions = 50; // how many positions to keep per player/vehicle when tracking
+	$keepTracksAfterLogout = 0; // 0 - remove player tracks after they logout, 1 - keep showing tracks
 	
 	//security
 	$security = "admin"; // allows you to rename the admin.php file to secure your install **Not Active Yet**


### PR DESCRIPTION
Added check for debug area coordinates when drawing player tracks, no more lines zooming in from corners of map

New config.php option: $keepTracksAfterLogout, optionally keep displaying player tracks after they logout

Added popup infowindow to player tracks when clicking on them
