### PR TITLE
Added start and end symbols to player/vehicle tracks

### DIFF
--- a/modules/map.php
+++ b/modules/map.php
@@ -184,12 +184,34 @@ if(!isset($map))
 			// if we didn't find an entry then we create one
 			if(!found) {
 				var pos = new google.maps.MVCArray([m.getPosition()]);
+				var startSymbol = {
+					path: google.maps.SymbolPath.CIRCLE,
+					fillColor: "green",
+					fillOpacity: 1,
+					scale: 3,
+					strokeColor: "green"
+				};
+				var endSymbol = {
+					path: google.maps.SymbolPath.FORWARD_CLOSED_ARROW,
+					fillColor: "yellow",
+					fillOpacity: 1,
+					scale: 2,
+					strokeColor: "yellow"
+				};
 				var line = new google.maps.Polyline({
 					strokeColor: '#c00000',
 					strokeOpacity: 0.8,
 					strokeWeight: 2,
 					uid: m.uid,
 					path: pos,
+					icons: [{
+						icon: startSymbol,
+						offset: '0%'
+					},
+					{
+						icon: endSymbol,
+						offset: '100%'
+					}],
 					title: m.title,
 					info: m.info
 				});


### PR DESCRIPTION
I found this useful mostly for tracks left behind after players had logged off.

Preview:
![tracking_update](https://f.cloud.github.com/assets/532318/130368/80450c72-7017-11e2-8220-a754426ef538.png)
