### PR TITLE
Removed revival

### DIFF
--- a/modules/info/1.php
+++ b/modules/info/1.php
@@ -391,22 +391,22 @@ foreach($res as $row) {
 </tr>
 <!-- Row 1 -->
 <tr>
-<td></td>
+<td><a href="admin.php?view=actions&healPlayer=<?php echo $row['unique_id']; ?>">Heal Player</a></td>
 <td><a href="admin.php?view=actions&teleportNE=<?php echo $row['unique_id']; ?>">North East Airfield</a></td>
 </tr>
 <!-- Row 2 -->
 <tr>
-<td><a href="admin.php?view=actions&healPlayer=<?php echo $row['unique_id']; ?>">Heal Player</a></td>
+<td><a href="admin.php?view=actions&killPlayer=<?php echo $row['unique_id']; ?>">Kill Player</a></td>
 <td><a href="admin.php?view=actions&teleportNW=<?php echo $row['unique_id']; ?>">North West Airfield</a></td>
 </tr>
 <!-- Row 3 -->
 <tr>
-<td><a href="admin.php?view=actions&killPlayer=<?php echo $row['unique_id']; ?>">Kill Player</a></td>
+<td><a href="admin.php?view=actions&resetHumanity=<?php echo $row['unique_id']; ?>">Reset Humanity</a></td>
 <td><a href="admin.php?view=actions&teleportStary=<?php echo $row['unique_id']; ?>">Stary Tents</a></td>
 </tr>
 <!-- Row 4 -->
 <tr>
-<td><a href="admin.php?view=actions&resetHumanity=<?php echo $row['unique_id']; ?>">Reset Humanity</a></td>
+<td></td>
 <td><a href="admin.php?view=actions&teleportCherno=<?php echo $row['unique_id']; ?>">Cherno</a></td>
 </tr>
 <!-- Row 5 -->


### PR DESCRIPTION
Removed revival of dead players due to dead players characters not being
viewable because the system does not target the ID of the survivor.

Pressing Revive would cause every survivor with the set unique_id to be
revived. Same with kill player, it would kill every character by the
player. But I left kill player there as there generally is only one
survivor alive from one player at a time

In short the system needs to be able to target the ID of the survivor in the survivor table for stuff like this to work properly. I'm not sure why this has been done yet. This is just a temporary solution to problems people may notice with 'Revive player' until I or someone else gets their head around to fixing this
